### PR TITLE
Trusted Header authentication

### DIFF
--- a/server/config/config.example.js
+++ b/server/config/config.example.js
@@ -29,6 +29,30 @@ module.exports =
 				redirect_uri  : 'https://client.example.com/auth/callback'
 			}
 
+		},
+		trustedheaders:
+		{
+			// The following maps http headers to the user
+		        // info the application uses. The accepted keys are:
+		        //
+			// - id
+			// - nickname
+			// - name
+			// - email
+			// - givenName
+			// - surName
+			// - picture
+			// - room
+			// - provider
+			headerMap:
+			{
+			    id:        'HTTP_HEADER_ID',
+			    name:      'HTTP_HEADER_NAME',
+			    email:     'HTTP_HEADER_MAIL',
+			    givenName: 'HTTP_HEADER_GIVEN_NAME',
+			    surName:   'HTTP_HEADER_SURNAME',
+			    provider:  'HTTP_HEADER_ORG'
+			}
 		}
 	},
 	*/

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
 		"openid-client": "^3.7.3",
 		"passport": "^0.4.0",
 		"passport-lti": "0.0.7",
+		"passport-trusted-header": "1.1.0",
 		"pidusage": "^2.0.17",
 		"redis": "^2.8.0",
 		"socket.io": "^2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
 		"express": "^4.17.1",
 		"express-session": "^1.17.0",
 		"express-socket.io-session": "^1.3.5",
+		"gravatar": "1.8.0",
 		"helmet": "^3.21.2",
 		"ims-lti": "^3.0.2",
 		"mediasoup": "^3.5.5",

--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,7 @@ const Room = require('./lib/Room');
 const Peer = require('./lib/Peer');
 const base64 = require('base-64');
 const helmet = require('helmet');
-
+const gravatar = require('gravatar');
 const {
 	loginHelper,
 	logoutHelper
@@ -380,19 +380,6 @@ function setupTrustedHeaders(headerMap)
 		{
 			id        : user_id,
 		};
-
-		if (user_picture != null && typeof(user_picture) !== undefined)
-		{
-			if (!user_picture.match(/^http/g))
-			{
-				user.picture = `data:image/jpeg;base64, ${user_picture}`;
-			}
-			else
-			{
-				user.picture = user_picture;
-			}
-		}
-
 		if (user_nickname != null && typeof(user_nickname) !== undefined)
 		{
 			user.displayName = user_nickname;
@@ -423,6 +410,21 @@ function setupTrustedHeaders(headerMap)
 		if (user_room != null && typeof(user_room) !== undefined)
 		{
 			user.room = user_room;
+		}
+		if (user_picture != null && typeof(user_picture) !== undefined)
+		{
+			if (!user_picture.match(/^http/g))
+			{
+				user.picture = `data:image/jpeg;base64, ${user_picture}`;
+			}
+			else
+			{
+				user.picture = user_picture;
+			}
+		} else {
+			if (user_email != null) {
+				user.picture = gravatar.url(user_email, {s: '100', protocol: 'https'});
+			}
 		}
 
 		logger.debug(util.inspect(user));

--- a/server/server.js
+++ b/server/server.js
@@ -367,7 +367,7 @@ function setupTrustedHeaders(headerMap)
 		{
 			id        : user_id,
 		};
-		
+
 		if (user_picture != null)
 		{
 			if (!user_picture.match(/^http/g))
@@ -406,7 +406,7 @@ function setupTrustedHeaders(headerMap)
 		{
 			user.provider = user_provider;
 		}
-		if (user_room != null) 
+		if (user_room != null)
 		{
 			user.room = user_room;
 		}


### PR DESCRIPTION
Here's my take on using proxy or trusted header authentication.

My use case was offering federated SAML login (which isn't supported by `passport-saml2`), but this will work for any use case delegating authentication to the proxy or load balancer placed in front of multiparty-meeting - as long as they pass along the information in HTTP headers.

Here's the Apache config I used for completeness sake:

```
ProxyPass /Shibboleth.sso !

RewriteCond %{REQUEST_URI}  ^/socket.io/?          [NC]
RewriteCond %{QUERY_STRING} transport=websocket    [NC]
RewriteRule /(.*)           ws://127.0.0.1:8080/$1 [P,L]

ProxyPass / http://127.0.0.1:8080/
ProxyPassReverse / http://127.0.0.1:8080/

ProxyPreserveHost On

<Location /auth/login>
        AuthType shibboleth
        ShibRequestSetting requireSession 1
        Require valid-user
</Location>

<ProxyMatch ^(?:http|ws)://127.0.0.1:8080>
        Require all granted

        RequestHeader set uid %{uid}e
        RequestHeader set mail %{mail}e
        RequestHeader set givenName %{givenName}e
        RequestHeader set sn %{sn}e
        RequestHeader set schacHomeOrganization %{schacHomeOrganization}e
        RequestHeader set X-Forwarded-Proto https
</ProxyMatch>
```