### PR TITLE
Promote all peers from lobby when a peer joins with the PROMOTE_PEER …

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -535,6 +535,13 @@ class Room extends EventEmitter
 				}
 
 				this._notification(peer.socket, 'roomReady', { turnServers });
+
+				if (config.activateOnHostJoin && this._lobby.peerList().length > 0 &&
+					!this._locked && peer.roles.some((role) =>
+					config.permissionsFromRoles.PROMOTE_PEER.includes(role)))
+				{
+					this._lobby.promoteAllPeers();
+				}
 			}
 		})
 			.catch((error) =>


### PR DESCRIPTION
Promote all peers from lobby when a peer joins with the PROMOTE_PEER permission and activateOnHostJoin is true in config #376 