### PR TITLE
Maybe fixed session peristance

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -623,8 +623,6 @@ class Room extends EventEmitter
 
 				peer.socket.handshake.session.token = token;
 
-				peer.socket.handshake.session.save();
-
 				let turnServers;
 
 				if ('turnAPIURI' in config)

--- a/server/server.js
+++ b/server/server.js
@@ -487,6 +487,9 @@ async function setupAuth()
 		}
 
 		req.logout();
+		req.session.passport = undefined;
+		req.session.touch();
+		req.session.save();
 		req.session.destroy(() => res.send(logoutHelper()));
 	});
 	// SAML metadata
@@ -694,10 +697,10 @@ function isPathAlreadyTaken(actualUrl)
  */
 async function runWebSocketServer()
 {
-	io = require('socket.io')(mainListener);
+	io = require('socket.io')(mainListener, { cookie: false });
 
 	io.use(
-		sharedSession(session, sharedCookieParser, { autoSave: true })
+		sharedSession(session, sharedCookieParser, {})
 	);
 
 	// Handle connections from clients.
@@ -777,6 +780,9 @@ async function runWebSocketServer()
 			}
 
 			room.handlePeer({ peer, returning });
+
+			socket.handshake.session.touch();
+			socket.handshake.session.save();
 
 			statusLog();
 		})


### PR DESCRIPTION
It is not a 100% fix. It just changed some timing parameters. I think there is some kind of race problem, or some order of calls between express and socked io issue.  At least with this code I was not able to reproduce the "passport not existing in session error".