### PR TITLE
Optionally enforce moderated access to all rooms.

### DIFF
--- a/server/config/config.example.js
+++ b/server/config/config.example.js
@@ -349,6 +349,12 @@ module.exports =
 	// When true, the room will be open to all users as long as there
 	// are allready users in the room
 	activateOnHostJoin   : true,
+	// roomsUnlocked is an array of rooms users can enter without waiting
+	// in the lobby.  If the array is undefined or null, users can enter
+	// any room without waiting in the lobby.  This is the default.  The
+	// aim of roomsUnlocked is to enforce moderated access to all rooms
+	// with the exception of the rooms defined in the array.
+	// roomsUnlocked        : [ 'unlocked1', 'unlocked2', 'unlocked3' ],
 	// When set, maxUsersPerRoom defines how many users can join
 	// a single room. If not set, there is no limit.
 	// maxUsersPerRoom    : 20,

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -261,7 +261,7 @@ class Room extends EventEmitter
 		this._queue = new AwaitQueue();
 
 		// Locked flag.
-		this._locked = false;
+		this._locked = config.roomsUnlocked && Array.isArray(config.roomsUnlocked) && !config.roomsUnlocked.includes(roomId)
 
 		// if true: accessCode is a possibility to open the room
 		this._joinByAccesCode = true;


### PR DESCRIPTION
Add the ability to optionally lock all rooms apart from those defined in
roomsUnlocked array in `server/config/config.js`.  The default behaviour is left
unchanged, i.e. users can freely enter any room without having to wait in the
lobby.