### PR TITLE
Partial revert of Special chars sanitization.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -620,20 +620,7 @@ async function runHttpsServer()
 				res.redirect(ltiURL);
 			}
 			else
-			{
-				const specialChars = "<>@!^*()[]{}:;|'\"\\,~`";
-
-				for (let i = 0; i < specialChars.length; i++)
-				{
-					if (req.url.substring(1).indexOf(specialChars[i]) > -1)
-					{
-						req.url = `/${encodeURIComponent(encodeURI(req.url.substring(1)))}`;
-						res.redirect(`${req.url}`);
-					}
-				}
-
 				return next();
-			}
 		}
 		else
 			res.redirect(`https://${req.hostname}${req.url}`);


### PR DESCRIPTION
https://github.com/edumeet/edumeet/commit/540eaff37d475bdc07d0998e29f7e7c0580e0b93 correctly replaced `encodeURI()` by `encodeURIComponent()` in `ChooseRoom.js` and `JoinDialog.js`. However, the new code added in server.js caused an extra issue: https://github.com/edumeet/edumeet/issues/634

As entering the rooms with special characters (e.g. `@`) seems to work without issues with just `s/encodeURI/encodeURIComponent/` remove the problematic code.