### PR TITLE
Hide specific user settings and refactor config.js

### DIFF
--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -49,13 +49,26 @@ var config =
 	mobileLastN          : 1,
 	// Highest number of lastN the user can select manually in UI
 	maxLastN             : 5,
-	// If truthy, users can NOT change number of speakers visible
-	lockLastN            : false,
 
 	// Position of notifications
 	notificationPosition : 'right',
 	// Timeout for autohiding topbar and button control bar
 	hideTimeout          : 3000,
+
+	// Settings hidden from UI
+	hiddenSettings: {
+		videoResolution   : false,
+		lastN             : false,
+		aspectRatio       : false,
+		advancedAudio     : false,
+		mirrorOwnVideo    : false,
+		permanentTopBar   : false,
+		hideMediaCtrl     : false,
+		separateMediaCtrl : false,
+		drawerOverContent : false,
+		showNotifications : false,
+		advancedTab       : false,
+	},
 
 	/**
 	 * Resolutions:

--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -54,6 +54,8 @@ var config =
 	notificationPosition : 'right',
 	// Timeout for autohiding topbar and button control bar
 	hideTimeout          : 3000,
+	// Disable the notification when a user joins the room
+	disableNotification  : false,
 
 	// Settings hidden from UI
 	hiddenSettings: {

--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -1,9 +1,95 @@
 // eslint-disable-next-line
 var config =
 {
-	loginEnabled    : false,
+	// Port configuration
 	developmentPort : 3443,
 	productionPort  : 443,
+
+	// Show logo if "logo" is not null, else show title
+	logo         : 'images/logo.example.png',
+	title        : 'edumeet',
+
+	// Service & Support URL
+	// if not set then not displayed on the about modals
+	supportUrl   : 'https://support.example.com',
+
+	// Privacy and dataprotection URL or path
+	// (privacy/privacy.html that is a placeholder for your policies)
+	privacyUrl   : 'privacy/privacy.html',
+
+	// Enable login through configured provider
+	loginEnabled : false,
+
+	/**
+	 * Set max number participants in one room that join 
+	 * unmuted. Next participant will join automatically muted
+	 * Default value is 4
+	 * 
+	 * Set it to 0 to auto mute all, 
+	 * Set it to negative (-1) to never automatically auto mute
+	 * but use it with caution
+	 * full mesh audio strongly decrease room capacity! 
+	 */
+	autoMuteThreshold    : 4,
+	background           : 'images/background.jpg',
+
+	// Democratic, Filmstrip
+	defaultLayout        : 'democratic',
+
+	// If true, will show media control buttons in separate
+	// control bar, not in the ME container.
+	buttonControlBar     : false,
+
+	// If false, will push videos away to make room for side
+	// drawer. If true, will overlay side drawer over videos
+	drawerOverlayed      : true,
+
+	// Max number of participant that will be visible as speaker
+	lastN                : 4,
+	mobileLastN          : 1,
+	// Highest number of lastN the user can select manually in UI
+	maxLastN             : 5,
+	// If truthy, users can NOT change number of speakers visible
+	lockLastN            : false,
+
+	// Position of notifications
+	notificationPosition : 'right',
+	// Timeout for autohiding topbar and button control bar
+	hideTimeout          : 3000,
+
+	/**
+	 * Resolutions:
+	 * 
+	 * low ~ 320x240
+	 * medium ~ 640x480
+	 * high ~ 1280x720
+	 * veryhigh ~ 1920x1080
+	 * ultra ~ 3840x2560
+	 * 
+	 * Frame rates: 1, 5, 10, 15, 20, 25, 30
+	 **/
+	defaultResolution             : 'medium',
+	defaultFrameRate              : 15,
+	defaultScreenResolution       : 'veryhigh',
+	defaultScreenSharingFrameRate : 5,
+
+	// The aspect ratio of the video from the camera
+	// this is not changeable in settings, only config
+	videoAspectRatio              : 1.777,
+
+	// The aspect ratio of the videos as shown on
+	// the screen. This is changeable in client settings.
+	// This value must match one of the defined values in
+	// viewAspectRatios EXACTLY (e.g. 1.333)
+	viewAspectRatio  : 1.777,
+	// These are the selectable aspect ratios in the settings
+	viewAspectRatios : [ {
+		value : 1.333, // 4 / 3
+		label : '4 : 3'
+	}, {
+		value : 1.777, // 16 / 9
+		label : '16 : 9'
+	} ],
 
 	/**
 	 * Supported browsers version 
@@ -26,49 +112,16 @@ var config =
 		'samsung internet for android' : '>=11.1.1.52'
 	},
 
-	/**
-	 * Resolutions:
-	 * 
-	 * low ~ 320x240
-	 * medium ~ 640x480
-	 * high ~ 1280x720
-	 * veryhigh ~ 1920x1080
-	 * ultra ~ 3840x2560
-	 * 
-	 **/
+	/* ---------- Advanced settings ---------- */
 
-	/**
-	 * Frame rates:
-	 * 
-	 * 1, 5, 10, 15, 20, 25, 30
-	 * 
-	 **/
-	// The aspect ratio of the videos as shown on
-	// the screen. This is changeable in client settings.
-	// This value must match one of the defined values in
-	// viewAspectRatios EXACTLY (e.g. 1.333)
-	viewAspectRatio  : 1.777,
-	// These are the selectable aspect ratios in the settings
-	viewAspectRatios : [ {
-		value : 1.333, // 4 / 3
-		label : '4 : 3'
-	}, {
-		value : 1.777, // 16 / 9
-		label : '16 : 9'
-	} ],
-	// The aspect ratio of the video from the camera
-	// this is not changeable in settings, only config
-	videoAspectRatio              : 1.777,
-	defaultResolution             : 'medium',
-	defaultFrameRate              : 15,
-	defaultScreenResolution       : 'veryhigh',
-	defaultScreenSharingFrameRate : 5,
 	// Enable or disable simulcast for webcam video
-	simulcast                     : true,
+	simulcast          : true,
+
 	// Enable or disable simulcast for screen sharing video
-	simulcastSharing              : false,
+	simulcastSharing   : false,
+
 	// Simulcast encoding layers and levels
-	simulcastEncodings            :
+	simulcastEncodings :
 	[
 		{ scaleResolutionDownBy: 4 },
 		{ scaleResolutionDownBy: 2 },
@@ -94,6 +147,7 @@ var config =
 		'chrome',
 		'opera'
 	],
+
 	// Socket.io request timeout
 	requestTimeout   : 20000,
 	requestRetries   : 3,
@@ -101,7 +155,8 @@ var config =
 	{
 		tcp : true
 	},
-	// defaults for audio setting on new clients / can be customized and overruled from client side
+
+	// Defaults for audio setting on new clients / can be customized and overruled from client side
 	defaultAudio:
 	{
 		autoGainControl      : false, // default : false
@@ -110,6 +165,7 @@ var config =
 		voiceActivatedUnmute : false, // default : false / Automatically unmute speaking above noisThereshold
 		noiseThreshold       : -60 // default -60 / This is only for voiceActivatedUnmute and audio-indicator
 	},
+
 	// Audio options for now only centrally from config file: 
 	centralAudioOptions:
 	{
@@ -123,51 +179,8 @@ var config =
 		opusPtime           : '20', // default : 20 / minimum packet time (3, 5, 10, 20, 40, 60, 120)
 		opusMaxPlaybackRate : 96000
 	},
-	/**
-	 * Set max number participants in one room that join 
-	 * unmuted. Next participant will join automatically muted
-	 * Default value is 4
-	 * 
-	 * Set it to 0 to auto mute all, 
-	 * Set it to negative (-1) to never automatically auto mute
-	 * but use it with caution
-	 * full mesh audio strongly decrease room capacity! 
-	 */
-	autoMuteThreshold    : 4,
-	background           : 'images/background.jpg',
-	defaultLayout        : 'democratic', // democratic, filmstrip
-	// If true, will show media control buttons in separate
-	// control bar, not in the ME container.
-	buttonControlBar     : false,
-	// If false, will push videos away to make room for side
-	// drawer. If true, will overlay side drawer over videos
-	drawerOverlayed      : true,
-	// Position of notifications
-	notificationPosition : 'right',
-	// Timeout for autohiding topbar and button control bar
-	hideTimeout          : 3000,
-	// max number of participant that will be visible in 
-	// as speaker
-	lastN                : 4,
-	mobileLastN          : 1,
-	// Highest number of lastN the user can select manually in 
-	// userinteface
-	maxLastN             : 5,
-	// If truthy, users can NOT change number of speakers visible
-	lockLastN            : false,
-	// Show logo if "logo" is not null, else show title
-	// Set logo file name using logo.* pattern like "logo.png" to not track it by git 
-	logo                 : 'images/logo.example.png',
-	title                : 'edumeet',
-	// Service & Support URL
-	// if not set then not displayed on the about modals
-	supportUrl           : 'https://support.example.com',
-	// Privacy and dataprotection URL or path
-	// by default privacy/privacy.html
-	// that is a placeholder for your policies
-	//
-	// but an external url could be also used here	 
-	privacyUrl           : 'privacy/privacy.html',
+
+	/* ---------- Theme settings ---------- */
 	theme                :
 	{
 		palette :

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -2849,17 +2849,20 @@ export default class RoomClient
 
 						this._spotlights.newPeer(id);
 
-						this._soundNotification();
+						if (window.config.disableJoinNotification)
+						{
+							this._soundNotification();
 
-						store.dispatch(requestActions.notify(
-							{
-								text : intl.formatMessage({
-									id             : 'room.newPeer',
-									defaultMessage : '{displayName} joined the room'
-								}, {
-									displayName
-								})
-							}));
+							store.dispatch(requestActions.notify(
+								{
+									text : intl.formatMessage({
+										id             : 'room.newPeer',
+										defaultMessage : '{displayName} joined the room'
+									}, {
+										displayName
+									})
+								}));
+						}
 
 						break;
 					}

--- a/app/src/components/Settings/AdvancedSettings.js
+++ b/app/src/components/Settings/AdvancedSettings.js
@@ -62,7 +62,7 @@ const AdvancedSettings = ({
 					defaultMessage : 'Notification sounds'
 				})}
 			/>
-			{ !window.config.lockLastN &&
+			{ !window.config.hiddenSettings.lastN &&
 				<form className={classes.setting} autoComplete='off'>
 					<FormControl className={classes.formControl}>
 						<Select

--- a/app/src/components/Settings/AppearanceSettings.js
+++ b/app/src/components/Settings/AppearanceSettings.js
@@ -84,39 +84,6 @@ const AppearanceSettings = (props) =>
 
 			<FormControl className={classes.setting}>
 				<Select
-					value={locale || ''}
-					onChange={(event) =>
-					{
-						if (event.target.value)
-							roomClient.setLocale(event.target.value);
-					}
-					}
-					name={intl.formatMessage({
-						id             : 'settings.language',
-						defaultMessage : 'Language'
-					})}
-					autoWidth
-					className={classes.selectEmpty}
-				>
-					{ localesList.map((item, index) =>
-					{
-						return (
-							<MenuItem key={index} value={item.locale[0]}>
-								{item.name}
-							</MenuItem>
-						);
-					})}
-				</Select>
-				<FormHelperText>
-					<FormattedMessage
-						id='settings.language'
-						defaultMessage='Select language'
-					/>
-				</FormHelperText>
-			</FormControl>
-
-			<FormControl className={classes.setting}>
-				<Select
 					value={room.mode || ''}
 					onChange={(event) =>
 					{

--- a/app/src/components/Settings/AppearanceSettings.js
+++ b/app/src/components/Settings/AppearanceSettings.js
@@ -80,6 +80,39 @@ const AppearanceSettings = (props) =>
 
 			<FormControl className={classes.setting}>
 				<Select
+					value={locale || ''}
+					onChange={(event) =>
+					{
+						if (event.target.value)
+							roomClient.setLocale(event.target.value);
+					}
+					}
+					name={intl.formatMessage({
+						id             : 'settings.language',
+						defaultMessage : 'Language'
+					})}
+					autoWidth
+					className={classes.selectEmpty}
+				>
+					{ localesList.map((item, index) =>
+					{
+						return (
+							<MenuItem key={index} value={item.locale[0]}>
+								{item.name}
+							</MenuItem>
+						);
+					})}
+				</Select>
+				<FormHelperText>
+					<FormattedMessage
+						id='settings.language'
+						defaultMessage='Select language'
+					/>
+				</FormHelperText>
+			</FormControl>
+
+			<FormControl className={classes.setting}>
+				<Select
 					value={room.mode || ''}
 					onChange={(event) =>
 					{

--- a/app/src/components/Settings/AppearanceSettings.js
+++ b/app/src/components/Settings/AppearanceSettings.js
@@ -37,10 +37,8 @@ const styles = (theme) =>
 const AppearanceSettings = (props) =>
 {
 	const {
-		roomClient,
 		isMobile,
 		room,
-		locale,
 		settings,
 		onTogglePermanentTopBar,
 		onToggleHiddenControls,
@@ -50,9 +48,7 @@ const AppearanceSettings = (props) =>
 		onToggleMirrorOwnVideo,
 		handleChangeMode,
 		handleChangeAspectRatio,
-		classes,
-		localesList
-
+		classes
 	} = props;
 
 	const intl = useIntl();
@@ -114,76 +110,87 @@ const AppearanceSettings = (props) =>
 				</FormHelperText>
 			</FormControl>
 
-			<FormControl className={classes.setting}>
-				<Select
-					value={settings.aspectRatio || ''}
-					onChange={(event) =>
-					{
-						if (event.target.value)
-							handleChangeAspectRatio(event.target.value);
-					}}
-					name={intl.formatMessage({
-						id             : 'settings.aspectRatio',
-						defaultMessage : 'Video aspect ratio'
+			{ !window.config.hiddenSettings.aspectRatio &&
+				<FormControl className={classes.setting}>
+					<Select
+						value={settings.aspectRatio || ''}
+						onChange={(event) =>
+						{
+							if (event.target.value)
+								handleChangeAspectRatio(event.target.value);
+						}}
+						name={intl.formatMessage({
+							id             : 'settings.aspectRatio',
+							defaultMessage : 'Video aspect ratio'
+						})}
+						autoWidth
+						className={classes.selectEmpty}
+					>
+						{ aspectRatios.map((aspectRatio, index) =>
+						{
+							return (
+								<MenuItem key={index} value={aspectRatio.value}>
+									{aspectRatio.label}
+								</MenuItem>
+							);
+						})}
+					</Select>
+					<FormHelperText>
+						<FormattedMessage
+							id='settings.selectAspectRatio'
+							defaultMessage='Select video aspect ratio'
+						/>
+					</FormHelperText>
+				</FormControl>
+			}
+			{ !window.config.hiddenSettings.mirrorOwnVideo &&
+				<FormControlLabel
+					className={classnames(classes.setting, classes.switchLabel)}
+					control={
+						<Switch checked={settings.mirrorOwnVideo} onChange={onToggleMirrorOwnVideo} value='mirrorOwnVideo' />}
+					labelPlacement='start'
+					label={intl.formatMessage({
+						id             : 'settings.mirrorOwnVideo',
+						defaultMessage : 'Mirror view of own video'
 					})}
-					autoWidth
-					className={classes.selectEmpty}
-				>
-					{ aspectRatios.map((aspectRatio, index) =>
-					{
-						return (
-							<MenuItem key={index} value={aspectRatio.value}>
-								{aspectRatio.label}
-							</MenuItem>
-						);
+				/>
+			}
+			{ !window.config.hiddenSettings.permanentTopBar &&
+				<FormControlLabel
+					className={classnames(classes.setting, classes.switchLabel)}
+					control={
+						<Switch checked={settings.permanentTopBar} onChange={onTogglePermanentTopBar} value='permanentTopBar' />}
+					labelPlacement='start'
+					label={intl.formatMessage({
+						id             : 'settings.permanentTopBar',
+						defaultMessage : 'Permanent top bar'
 					})}
-				</Select>
-				<FormHelperText>
-					<FormattedMessage
-						id='settings.selectAspectRatio'
-						defaultMessage='Select video aspect ratio'
-					/>
-				</FormHelperText>
-			</FormControl>
-			<FormControlLabel
-				className={classnames(classes.setting, classes.switchLabel)}
-				control={
-					<Switch checked={settings.mirrorOwnVideo} onChange={onToggleMirrorOwnVideo} value='mirrorOwnVideo' />}
-				labelPlacement='start'
-				label={intl.formatMessage({
-					id             : 'settings.mirrorOwnVideo',
-					defaultMessage : 'Mirror view of own video'
-				})}
-			/>
-			<FormControlLabel
-				className={classnames(classes.setting, classes.switchLabel)}
-				control={
-					<Switch checked={settings.permanentTopBar} onChange={onTogglePermanentTopBar} value='permanentTopBar' />}
-				labelPlacement='start'
-				label={intl.formatMessage({
-					id             : 'settings.permanentTopBar',
-					defaultMessage : 'Permanent top bar'
-				})}
-			/>
-			<FormControlLabel
-				className={classnames(classes.setting, classes.switchLabel)}
-				control={<Switch checked={settings.hiddenControls} onChange={onToggleHiddenControls} value='hiddenControls' />}
-				labelPlacement='start'
-				label={intl.formatMessage({
-					id             : 'settings.hiddenControls',
-					defaultMessage : 'Hidden media controls'
-				})}
-			/>
-			<FormControlLabel
-				className={classnames(classes.setting, classes.switchLabel)}
-				control={<Switch checked={settings.buttonControlBar} onChange={onToggleButtonControlBar} value='buttonControlBar' />}
-				labelPlacement='start'
-				label={intl.formatMessage({
-					id             : 'settings.buttonControlBar',
-					defaultMessage : 'Separate media controls'
-				})}
-			/>
-			{ !isMobile &&
+				/>
+			}
+			{ !window.config.hiddenSettings.hideMediaCtrl &&
+				<FormControlLabel
+					className={classnames(classes.setting, classes.switchLabel)}
+					control={<Switch checked={settings.hiddenControls} onChange={onToggleHiddenControls} value='hiddenControls' />}
+					labelPlacement='start'
+					label={intl.formatMessage({
+						id             : 'settings.hiddenControls',
+						defaultMessage : 'Hidden media controls'
+					})}
+				/>
+			}
+
+			{ !window.config.hiddenSettings.separateMediaCtrl &&
+				<FormControlLabel
+					className={classnames(classes.setting, classes.switchLabel)}
+					control={<Switch checked={settings.buttonControlBar} onChange={onToggleButtonControlBar} value='buttonControlBar' />}
+					labelPlacement='start'
+					label={intl.formatMessage({
+						id             : 'settings.buttonControlBar',
+						defaultMessage : 'Separate media controls'
+					})}
+				/>
+			}
+			{ !isMobile && !window.config.hiddenSettings.drawerOverContent &&
 				<FormControlLabel
 					className={classnames(classes.setting, classes.switchLabel)}
 					control={<Switch checked={settings.drawerOverlayed} onChange={onToggleDrawerOverlayed} value='drawerOverlayed' />}
@@ -194,15 +201,17 @@ const AppearanceSettings = (props) =>
 					})}
 				/>
 			}
-			<FormControlLabel
-				className={classnames(classes.setting, classes.switchLabel)}
-				control={<Switch checked={settings.showNotifications} onChange={onToggleShowNotifications} value='showNotifications' />}
-				labelPlacement='start'
-				label={intl.formatMessage({
-					id             : 'settings.showNotifications',
-					defaultMessage : 'Show notifications'
-				})}
-			/>
+			{ !window.config.hiddenSettings.showNotifications &&
+				<FormControlLabel
+					className={classnames(classes.setting, classes.switchLabel)}
+					control={<Switch checked={settings.showNotifications} onChange={onToggleShowNotifications} value='showNotifications' />}
+					labelPlacement='start'
+					label={intl.formatMessage({
+						id             : 'settings.showNotifications',
+						defaultMessage : 'Show notifications'
+					})}
+				/>
+			}
 		</React.Fragment>
 	);
 };

--- a/app/src/components/Settings/MediaSettings.js
+++ b/app/src/components/Settings/MediaSettings.js
@@ -201,84 +201,29 @@ const MediaSettings = ({
 						}
 					</FormHelperText>
 				</FormControl>
-				<List className={classes.root} component='nav'>
-					<ListItem button onClick={() => setVideoSettingsOpen(!videoSettingsOpen)}>
-						<ListItemText primary={intl.formatMessage({
-							id             : 'settings.showAdvancedVideo',
-							defaultMessage : 'Advanced video settings'
-						})}
-						/>
-						{videoSettingsOpen ? <ExpandLess /> : <ExpandMore />}
-					</ListItem>
-					<Collapse in={videoSettingsOpen} timeout='auto'>
-						<FormControl className={classes.formControl}>
-							<Select
-								value={settings.resolution || ''}
-								onChange={(event) =>
-								{
-									if (event.target.value)
-										roomClient.updateWebcam({ newResolution: event.target.value });
-								}}
-								name='Video resolution'
-								autoWidth
-								className={classes.selectEmpty}
-							>
-								{resolutions.map((resolution, index) =>
-								{
-									return (
-										<MenuItem key={index} value={resolution.value}>
-											{resolution.label}
-										</MenuItem>
-									);
-								})}
-							</Select>
-							<FormHelperText>
-								<FormattedMessage
-									id='settings.resolution'
-									defaultMessage='Select your video resolution'
-								/>
-							</FormHelperText>
-						</FormControl>
-						{ /*
+				{ !window.config.hiddenSettings.videoResolution &&
+					<List className={classes.root} component='nav'>
+						<ListItem button onClick={() => setVideoSettingsOpen(!videoSettingsOpen)}>
+							<ListItemText primary={intl.formatMessage({
+								id             : 'settings.showAdvancedVideo',
+								defaultMessage : 'Advanced video settings'
+							})}
+							/>
+							{videoSettingsOpen ? <ExpandLess /> : <ExpandMore />}
+						</ListItem>
+						<Collapse in={videoSettingsOpen} timeout='auto'>
 							<FormControl className={classes.formControl}>
 								<Select
-									value={settings.frameRate || ''}
+									value={settings.resolution || ''}
 									onChange={(event) =>
 									{
 										if (event.target.value)
-											roomClient.updateWebcam({ newFrameRate: event.target.value });
+											roomClient.updateWebcam({ newResolution: event.target.value });
 									}}
-									name='Frame rate'
+									name='Video resolution'
 									autoWidth
 									className={classes.selectEmpty}
-								>
-									{ [ 1, 5, 10, 15, 20, 25, 30 ].map((frameRate) =>
-									{
-										return (
-											<MenuItem key={frameRate} value={frameRate}>
-												{frameRate}
-											</MenuItem>
-										);
-									})}
-								</Select>
-								<FormHelperText>
-									<FormattedMessage
-										id='settings.frameRate'
-										defaultMessage='Select your video frame rate'
-									/>
-								</FormHelperText>
-							</FormControl>
-							<FormControl className={classes.formControl}>
-								<Select
-									value={settings.screenSharingResolution || ''}
-									onChange={(event) =>
-									{
-										if (event.target.value)
-											roomClient.updateScreenSharing({ newResolution: event.target.value });
-									}}
-									name='Screen sharing resolution'
-									autoWidth
-									className={classes.selectEmpty}
+									disabled={window.config.hiddenSettings.videoResolution}
 								>
 									{resolutions.map((resolution, index) =>
 									{
@@ -291,42 +236,106 @@ const MediaSettings = ({
 								</Select>
 								<FormHelperText>
 									<FormattedMessage
-										id='settings.screenSharingResolution'
-										defaultMessage='Select your screen sharing resolution'
+										id='settings.resolution'
+										defaultMessage='Select your video resolution'
 									/>
 								</FormHelperText>
 							</FormControl>
-						*/ }
-						<FormControl className={classes.formControl}>
-							<Select
-								value={settings.screenSharingFrameRate || ''}
-								onChange={(event) =>
-								{
-									if (event.target.value)
-										roomClient.updateScreenSharing({ newFrameRate: event.target.value });
-								}}
-								name='Frame rate'
-								autoWidth
-								className={classes.selectEmpty}
-							>
-								{ [ 1, 5, 10, 15, 20, 25, 30 ].map((screenSharingFrameRate) =>
-								{
-									return (
-										<MenuItem key={screenSharingFrameRate} value={screenSharingFrameRate}>
-											{screenSharingFrameRate}
-										</MenuItem>
-									);
-								})}
-							</Select>
-							<FormHelperText>
-								<FormattedMessage
-									id='settings.screenSharingFrameRate'
-									defaultMessage='Select your screen sharing frame rate'
-								/>
-							</FormHelperText>
-						</FormControl>
-					</Collapse>
-				</List>
+							{ /*
+								<FormControl className={classes.formControl}>
+									<Select
+										value={settings.frameRate || ''}
+										onChange={(event) =>
+										{
+											if (event.target.value)
+												roomClient.updateWebcam({ newFrameRate: event.target.value });
+										}}
+										name='Frame rate'
+										autoWidth
+										className={classes.selectEmpty}
+									>
+										{ [ 1, 5, 10, 15, 20, 25, 30 ].map((frameRate) =>
+										{
+											return (
+												<MenuItem key={frameRate} value={frameRate}>
+													{frameRate}
+												</MenuItem>
+											);
+										})}
+									</Select>
+									<FormHelperText>
+										<FormattedMessage
+											id='settings.frameRate'
+											defaultMessage='Select your video frame rate'
+										/>
+									</FormHelperText>
+								</FormControl>
+								<FormControl className={classes.formControl}>
+									<Select
+										value={settings.screenSharingResolution || ''}
+										onChange={(event) =>
+										{
+											if (event.target.value)
+												roomClient.updateScreenSharing({ newResolution: event.target.value });
+										}}
+										name='Screen sharing resolution'
+										autoWidth
+										className={classes.selectEmpty}
+									>
+										{resolutions.map((resolution, index) =>
+										{
+											return (
+												<MenuItem key={index} value={resolution.value}>
+													{resolution.label}
+												</MenuItem>
+											);
+										})}
+									</Select>
+									<FormHelperText>
+										<FormattedMessage
+											id='settings.screenSharingResolution'
+											defaultMessage='Select your screen sharing resolution'
+										/>
+									</FormHelperText>
+								</FormControl>
+							*/ }
+							<FormControl className={classes.formControl}>
+								<Select
+									value={settings.screenSharingFrameRate || ''}
+									onChange={(event) =>
+									{
+										if (event.target.value)
+											roomClient.updateScreenSharing({
+												newFrameRate : event.target.value
+											});
+									}}
+									name='Frame rate'
+									autoWidth
+									className={classes.selectEmpty}
+									disabled={window.config.hiddenSettings.videoResolution}
+								>
+									{ [ 1, 5, 10, 15, 20, 25, 30 ].map((screenSharingFrameRate) =>
+									{
+										return (
+											<MenuItem
+												key={screenSharingFrameRate}
+												value={screenSharingFrameRate}
+											>
+												{screenSharingFrameRate}
+											</MenuItem>
+										);
+									})}
+								</Select>
+								<FormHelperText>
+									<FormattedMessage
+										id='settings.screenSharingFrameRate'
+										defaultMessage='Select your screen sharing frame rate'
+									/>
+								</FormHelperText>
+							</FormControl>
+						</Collapse>
+					</List>
+				}
 			</form>
 			<form className={classes.setting} autoComplete='off'>
 				<FormControl className={classes.formControl}>
@@ -414,118 +423,145 @@ const MediaSettings = ({
 					</FormControl>
 				}
 				<List className={classes.root} component='nav'>
-					<ListItem button onClick={() => setAudioSettingsOpen(!audioSettingsOpen)}>
-						<ListItemText primary={intl.formatMessage({
-							id             : 'settings.showAdvancedAudio',
-							defaultMessage : 'Advanced audio settings'
-						})}
-						/>
-						{audioSettingsOpen ? <ExpandLess /> : <ExpandMore />}
-					</ListItem>
-					<Collapse in={audioSettingsOpen} timeout='auto'>
-						<List component='div'>
-							<ListItem className={classes.nested}>
-								<FormControlLabel
-									className={classnames(classes.setting, classes.switchLabel)}
-									control={
-										<Switch color='secondary'
-											checked={settings.echoCancellation}
-											onChange={
-												(event) =>
-												{
-													setEchoCancellation(event.target.checked);
-													roomClient.updateMic();
-												}}
-										/>}
-									labelPlacement='start'
-									label={intl.formatMessage({
-										id             : 'settings.echoCancellation',
-										defaultMessage : 'Echo cancellation'
-									})}
-								/>
-							</ListItem>
-							<ListItem className={classes.nested}>
-								<FormControlLabel
-									className={classnames(classes.setting, classes.switchLabel)}
-									control={
-										<Switch color='secondary'
-											checked={settings.autoGainControl} onChange={
-												(event) =>
-												{
-													setAutoGainControl(event.target.checked);
-													roomClient.updateMic();
-												}}
-										/>}
-									labelPlacement='start'
-									label={intl.formatMessage({
-										id             : 'settings.autoGainControl',
-										defaultMessage : 'Auto gain control'
-									})}
-								/>
-							</ListItem>
-							<ListItem className={classes.nested}>
-								<FormControlLabel
-									className={classnames(classes.setting, classes.switchLabel)}
-									control={
-										<Switch color='secondary'
-											checked={settings.noiseSuppression} onChange={
-												(event) =>
-												{
-													setNoiseSuppression(event.target.checked);
-													roomClient.updateMic();
-												}}
-										/>}
-									labelPlacement='start'
-									label={intl.formatMessage({
-										id             : 'settings.noiseSuppression',
-										defaultMessage : 'Noise suppression'
-									})}
-								/>
-							</ListItem>
-							<ListItem className={classes.nested}>
-								<FormControlLabel
-									className={classnames(classes.setting, classes.switchLabel)}
-									control={
-										<Switch color='secondary'
-											checked={settings.voiceActivatedUnmute} onChange={
-												(event) =>
-												{
-													setVoiceActivatedUnmute(event.target.checked);
-												}}
-										/>}
-									labelPlacement='start'
-									label={intl.formatMessage({
-										id             : 'settings.voiceActivatedUnmute',
-										defaultMessage : 'Voice activated unmute'
-									})}
-								/>
-							</ListItem>
-							<ListItem className={classes.nested}>
-								<div className={classes.margin} />
-								<Typography gutterBottom>
-									{
-										intl.formatMessage({
-											id             : 'settings.noiseThreshold',
-											defaultMessage : 'Noise threshold'
-										})
-									}:
-								</Typography>
-								<NoiseSlider className={classnames(classes.slider, classnames.setting)}
-									key={'noise-threshold-slider'}
-									min={-100}
-									value={settings.noiseThreshold}
-									max={0}
-									valueLabelDisplay={'auto'}
-									onChange={
-										(event, value) =>
+					{ !window.config.hiddenSettings.advancedAudio ?
+						<ListItem button onClick={() => setAudioSettingsOpen(!audioSettingsOpen)}>
+							<ListItemText primary={intl.formatMessage({
+								id             : 'settings.showAdvancedAudio',
+								defaultMessage : 'Advanced audio settings'
+							})}
+							/>
+							{audioSettingsOpen ? <ExpandLess /> : <ExpandMore />}
+						</ListItem> &&
+						<Collapse in={audioSettingsOpen} timeout='auto'>
+							<List component='div'>
+								<ListItem className={classes.nested}>
+									<FormControlLabel
+										className={classnames(classes.setting, classes.switchLabel)}
+										control={
+											<Switch color='secondary'
+												checked={settings.echoCancellation}
+												onChange={
+													(event) =>
+													{
+														setEchoCancellation(event.target.checked);
+														roomClient.updateMic();
+													}}
+											/>}
+										labelPlacement='start'
+										label={intl.formatMessage({
+											id             : 'settings.echoCancellation',
+											defaultMessage : 'Echo cancellation'
+										})}
+									/>
+								</ListItem>
+								<ListItem className={classes.nested}>
+									<FormControlLabel
+										className={classnames(classes.setting, classes.switchLabel)}
+										control={
+											<Switch color='secondary'
+												checked={settings.autoGainControl} onChange={
+													(event) =>
+													{
+														setAutoGainControl(event.target.checked);
+														roomClient.updateMic();
+													}}
+											/>}
+										labelPlacement='start'
+										label={intl.formatMessage({
+											id             : 'settings.autoGainControl',
+											defaultMessage : 'Auto gain control'
+										})}
+									/>
+								</ListItem>
+								<ListItem className={classes.nested}>
+									<FormControlLabel
+										className={classnames(classes.setting, classes.switchLabel)}
+										control={
+											<Switch color='secondary'
+												checked={settings.noiseSuppression} onChange={
+													(event) =>
+													{
+														setNoiseSuppression(event.target.checked);
+														roomClient.updateMic();
+													}}
+											/>}
+										labelPlacement='start'
+										label={intl.formatMessage({
+											id             : 'settings.noiseSuppression',
+											defaultMessage : 'Noise suppression'
+										})}
+									/>
+								</ListItem>
+								<ListItem className={classes.nested}>
+									<FormControlLabel
+										className={classnames(classes.setting, classes.switchLabel)}
+										control={
+											<Switch color='secondary'
+												checked={settings.voiceActivatedUnmute} onChange={
+													(event) =>
+													{
+														setVoiceActivatedUnmute(event.target.checked);
+													}}
+											/>}
+										labelPlacement='start'
+										label={intl.formatMessage({
+											id             : 'settings.voiceActivatedUnmute',
+											defaultMessage : 'Voice activated unmute'
+										})}
+									/>
+								</ListItem>
+								<ListItem className={classes.nested}>
+									<div className={classes.margin} />
+									<Typography gutterBottom>
 										{
-											roomClient._setNoiseThreshold(value);
-										}}
-									marks={[ { value: volume, label: `${volume.toFixed(0)} dB` } ]}
-								/>
-							</ListItem>
-						</List>
-					</Collapse>
+											intl.formatMessage({
+												id             : 'settings.noiseThreshold',
+												defaultMessage : 'Noise threshold'
+											})
+										}:
+									</Typography>
+									<NoiseSlider className={classnames(classes.slider, classnames.setting)}
+										key={'noise-threshold-slider'}
+										min={-100}
+										value={settings.noiseThreshold}
+										max={0}
+										valueLabelDisplay={'auto'}
+										onChange={
+											(event, value) =>
+											{
+												roomClient._setNoiseThreshold(value);
+											}}
+										marks={[ { value: volume, label: `${volume.toFixed(0)} dB` } ]}
+									/>
+								</ListItem>
+							</List>
+						</Collapse>
+						:
+						<div>
+							<div className={classes.margin} />
+							<Typography gutterBottom>
+								{
+									intl.formatMessage({
+										id             : 'settings.noiseThreshold',
+										defaultMessage : 'Noise threshold'
+									})
+								}:
+							</Typography>
+							<NoiseSlider className={classnames(classes.slider, classnames.setting)}
+								key={'noise-threshold-slider'}
+								min={-100}
+								value={settings.noiseThreshold}
+								max={0}
+								valueLabelDisplay={'auto'}
+								onChange={
+									(event, value) =>
+									{
+										roomClient._setNoiseThreshold(value);
+									}}
+								marks={[ { value: volume, label: `${volume.toFixed(0)} dB` } ]}
+							/>
+						</div>
+					}
 				</List>
 			</form>
 		</React.Fragment>

--- a/app/src/components/Settings/Settings.js
+++ b/app/src/components/Settings/Settings.js
@@ -99,12 +99,14 @@ const Settings = ({
 						defaultMessage : 'Appearance'
 					})}
 				/>
-				<Tab
-					label={intl.formatMessage({
-						id             : 'label.advanced',
-						defaultMessage : 'Advanced'
-					})}
-				/>
+				{ !window.config.hiddenSettings.advancedTab &&
+					<Tab
+						label={intl.formatMessage({
+							id             : 'label.advanced',
+							defaultMessage : 'Advanced'
+						})}
+					/>
+				}
 			</Tabs>
 			{currentSettingsTab === 'media' && <MediaSettings />}
 			{currentSettingsTab === 'appearance' && <AppearanceSettings />}


### PR DESCRIPTION
Changes:
 - Refactor `config.js` options by relevance
 - Add option to hide specific options to end-user (video settings, advanced, ecc...)
 - Add option to disable join notifications (added by users feedback)

You can check this changes on our server (changes from other PRs are merged too): https://befair1.iorestoacasa.work/