### PR TITLE
Server hostname configuration

### DIFF
--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -4,6 +4,9 @@ var config =
 	loginEnabled    : false,
 	developmentPort : 3443,
 	productionPort  : 443,
+	// of the server component runs on a different host than the app
+	// you can uncomment the following line and specify the host name.
+	// serverHostname  : 'external-server.com',
 
 	/**
 	 * Supported browsers version 

--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -4,9 +4,9 @@ var config =
 	loginEnabled    : false,
 	developmentPort : 3443,
 	productionPort  : 443,
-	// of the server component runs on a different host than the app
+	// If the server component runs on a different host than the app
 	// you can uncomment the following line and specify the host name.
-	// serverHostname  : 'external-server.com',
+	//serverHostname  : 'external-server.com',
 
 	/**
 	 * Supported browsers version 

--- a/app/src/urlFactory.js
+++ b/app/src/urlFactory.js
@@ -1,12 +1,13 @@
 export function getSignalingUrl(peerId, roomId)
 {
+	const hostname = window.config.serverHostname || window.location.hostname;
 	const port =
 		process.env.NODE_ENV !== 'production' ?
 			window.config.developmentPort
 			:
 			window.config.productionPort;
 
-	const url = `wss://${window.location.hostname}:${port}/?peerId=${peerId}&roomId=${roomId}`;
+	const url = `wss://${hostname}:${port}/?peerId=${peerId}&roomId=${roomId}`;
 
 	return url;
 }


### PR DESCRIPTION
Add an optional `serverHostname` property to app configuration to configure an external server url.
Closes #677 