### PR TITLE
Avoid crashing the server process when exiting interactive sessions

### DIFF
--- a/server/lib/interactiveServer.js
+++ b/server/lib/interactiveServer.js
@@ -684,6 +684,11 @@ module.exports = async function(rooms, peers)
 			const interactive = new Interactive(socket);
 
 			interactive.openCommandConsole();
+			
+			socket.on('error', (error) =>
+			{
+				console.error(`interactiveServer socket error:`, error.message);
+			});
 		});
 
 		await new Promise((resolve) =>


### PR DESCRIPTION
When using the interactive socket connection (`socat - UNIX-CONNECT:/tmp/edumeet-server.sock`), closing the command line session throws a not handled exception that crashes the server process.