### PR TITLE
Enforce entering participant's name on entry.

### DIFF
--- a/app/src/components/JoinDialog.js
+++ b/app/src/components/JoinDialog.js
@@ -285,9 +285,6 @@ const JoinDialog = ({
 			{
 				displayName = displayName.trim();
 
-				if (displayName === '')
-					changeDisplayName(
-						`Guest ${Math.floor(Math.random() * (100000 - 10000)) + 10000}`);
 				if (room.inLobby)
 					roomClient.changeDisplayName(displayName);
 				break;
@@ -548,8 +545,6 @@ const JoinDialog = ({
 						{
 							displayName = displayName.trim();
 
-							if (displayName === '')
-								changeDisplayName(`Guest ${Math.floor(Math.random() * (100000 - 10000)) + 10000}`);
 							if (room.inLobby)
 								roomClient.changeDisplayName(displayName);
 						}}
@@ -656,6 +651,7 @@ const JoinDialog = ({
 									variant='contained'
 									color='primary'
 									id='joinButton'
+									disabled={displayName === ''}
 								>
 									<FormattedMessage
 										id='label.join'

--- a/app/src/reducers/settings.js
+++ b/app/src/reducers/settings.js
@@ -1,6 +1,6 @@
 const initialState =
 {
-	displayName             : `Guest ${Math.floor(Math.random() * (100000 - 10000)) + 10000}`,
+	displayName             : '',
 	selectedWebcam          : null,
 	selectedAudioDevice     : null,
 	advancedMode            : false,


### PR DESCRIPTION
While it can be quite comfortable to enter a conference for the first time quickly without entering participant's username, it also often creates situations where a large chunk of participants are called "Guest random_number".  This change enforces users to enter their name/nick prior to entering the room/lobby by graying out the <join> button if the participant's name is blank.

