### PR TITLE
Define simulcast encodings per resolution

### DIFF
--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -74,14 +74,14 @@ var config =
 	{
 		3840 :
 		[
-			{ scaleResolutionDownBy: 6, maxBitRate: 750000 },
-			{ scaleResolutionDownBy: 3, maxBitRate: 1500000 },
+			{ scaleResolutionDownBy: 4, maxBitRate: 1500000 },
+			{ scaleResolutionDownBy: 2, maxBitRate: 4000000 },
 			{ scaleResolutionDownBy: 1, maxBitRate: 10000000 }
 		],
 		1920 :
 		[
-			{ scaleResolutionDownBy: 6, maxBitRate: 250000 },
-			{ scaleResolutionDownBy: 3, maxBitRate: 900000 },
+			{ scaleResolutionDownBy: 4, maxBitRate: 750000 },
+			{ scaleResolutionDownBy: 2, maxBitRate: 1500000 },
 			{ scaleResolutionDownBy: 1, maxBitRate: 4000000 }
 		],
 		1280 :
@@ -100,6 +100,7 @@ var config =
 			{ scaleResolutionDownBy: 1, maxBitRate: 250000 }
 		]
 	},
+
 
 	// The adaptive spatial layer selection scaling factor (in the range [0.5, 1.0])
 	// example: 

--- a/app/public/config/config.example.js
+++ b/app/public/config/config.example.js
@@ -70,27 +70,42 @@ var config =
 	simulcast                     : true,
 	// Enable or disable simulcast for screen sharing video
 	simulcastSharing              : false,
-	// Simulcast encoding layers and levels
-	simulcastEncodings            :
-	[
-		{ scaleResolutionDownBy: 4 },
-		{ scaleResolutionDownBy: 2 },
-		{ scaleResolutionDownBy: 1 }
-	],
+	simulcastProfiles :
+	{
+		3840 :
+		[
+			{ scaleResolutionDownBy: 6, maxBitRate: 750000 },
+			{ scaleResolutionDownBy: 3, maxBitRate: 1500000 },
+			{ scaleResolutionDownBy: 1, maxBitRate: 10000000 }
+		],
+		1920 :
+		[
+			{ scaleResolutionDownBy: 6, maxBitRate: 250000 },
+			{ scaleResolutionDownBy: 3, maxBitRate: 900000 },
+			{ scaleResolutionDownBy: 1, maxBitRate: 4000000 }
+		],
+		1280 :
+		[
+			{ scaleResolutionDownBy: 4, maxBitRate: 250000 },
+			{ scaleResolutionDownBy: 2, maxBitRate: 900000 },
+			{ scaleResolutionDownBy: 1, maxBitRate: 3000000 }
+		],
+		640 :
+		[
+			{ scaleResolutionDownBy: 2, maxBitRate: 250000 },
+			{ scaleResolutionDownBy: 1, maxBitRate: 900000 }
+		],
+		320 :
+		[
+			{ scaleResolutionDownBy: 1, maxBitRate: 250000 }
+		]
+	},
+
 	// The adaptive spatial layer selection scaling factor (in the range [0.5, 1.0])
 	// example: 
 	// with level width=640px, the minimum width required to trigger the
 	// level change will be: 640 * 0.75 = 480px
 	adaptiveScalingFactor: 0.75,
-
-	/**
-	 * Alternative simulcast setting:
-	 * [
-	 *   { maxBitRate: 50000 }, 
-	 *	 { maxBitRate: 1000000 },
-	 *	 { maxBitRate: 4800000 }
-	 *],
-	 **/
 
 	/**
 	 * White listing browsers that support audio output device selection.

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -97,14 +97,14 @@ const VIDEO_SIMULCAST_PROFILES =
 {
 	3840 :
 	[
-		{ scaleResolutionDownBy: 6, maxBitRate: 750000 },
-		{ scaleResolutionDownBy: 3, maxBitRate: 1500000 },
+		{ scaleResolutionDownBy: 4, maxBitRate: 1500000 },
+		{ scaleResolutionDownBy: 2, maxBitRate: 4000000 },
 		{ scaleResolutionDownBy: 1, maxBitRate: 10000000 }
 	],
 	1920 :
 	[
-		{ scaleResolutionDownBy: 6, maxBitRate: 250000 },
-		{ scaleResolutionDownBy: 3, maxBitRate: 900000 },
+		{ scaleResolutionDownBy: 4, maxBitRate: 750000 },
+		{ scaleResolutionDownBy: 2, maxBitRate: 1500000 },
 		{ scaleResolutionDownBy: 1, maxBitRate: 4000000 }
 	],
 	1280 :


### PR DESCRIPTION
This could solve #713 
It is backward compatible with old settings, so it should not break current configs.
@so010 @vpalmisano 