### PR TITLE
Per-stream, client-side volume control.

### DIFF
--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -2167,6 +2167,38 @@ export default class RoomClient
 				peerActions.setPeerScreenInProgress(peerId, false));
 	}
 
+	async setAudioGain(micConsumer, peerId, audioGain)
+	{
+		logger.debug(
+			'setAudioGain() [micConsumer:"%o", peerId:"%s", type:"%s"]',
+			micConsumer,
+			peerId,
+			audioGain
+		);
+
+		if (!micConsumer)
+		{
+			return;
+		}
+
+		micConsumer.audioGain = audioGain;
+
+		try
+		{
+			for (const consumer of this._consumers.values())
+			{
+				if (consumer.appData.peerId === peerId)
+				{
+					store.dispatch(consumerActions.setConsumerAudioGain(consumer.id, audioGain));
+				}
+			}
+		}
+		catch (error)
+		{
+			logger.error('setAudioGain() [error:"%o"]', error);
+		}
+	}
+
 	async _pauseConsumer(consumer)
 	{
 		logger.debug('_pauseConsumer() [consumer:"%o"]', consumer);
@@ -3237,7 +3269,8 @@ export default class RoomClient
 							priority               : 1,
 							codec                  : consumer.rtpParameters.codecs[0].mimeType.split('/')[1],
 							track                  : consumer.track,
-							score                  : score
+							score                  : score,
+							audioGain              : undefined
 						};
 
 						this._spotlights.addVideoConsumer(consumerStoreObject);

--- a/app/src/actions/consumerActions.js
+++ b/app/src/actions/consumerActions.js
@@ -56,3 +56,9 @@ export const setConsumerScore = (consumerId, score) =>
 		type    : 'SET_CONSUMER_SCORE',
 		payload : { consumerId, score }
 	});
+
+export const setConsumerAudioGain = (consumerId, audioGain) =>
+	({
+		type    : 'SET_CONSUMER_AUDIO_GAIN',
+		payload : { consumerId, audioGain }
+	});

--- a/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
@@ -19,6 +19,7 @@ import VideocamOffIcon from '@material-ui/icons/VideocamOff';
 import MicIcon from '@material-ui/icons/Mic';
 import MicOffIcon from '@material-ui/icons/MicOff';
 import VolumeUpIcon from '@material-ui/icons/VolumeUp';
+import VolumeDownIcon from '@material-ui/icons/VolumeDown';
 import VolumeOffIcon from '@material-ui/icons/VolumeOff';
 import ScreenIcon from '@material-ui/icons/ScreenShare';
 import ScreenOffIcon from '@material-ui/icons/StopScreenShare';
@@ -32,6 +33,8 @@ import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import MoreIcon from '@material-ui/icons/MoreVert';
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
+import ListItem from '@material-ui/core/ListItem';
+import Slider from '@material-ui/core/Slider';
 
 const styles = (theme) =>
 	({
@@ -80,6 +83,33 @@ const styles = (theme) =>
 			color : 'rgba(220, 0, 78, 1)'
 		}
 	});
+
+const VolumeSlider = withStyles(
+	{
+		root :
+		{
+			color   : '#3880ff',
+			height  : 2,
+			padding : '15px 0'
+		},
+		track : {
+			height : 2
+		},
+		rail : {
+			height  : 2,
+			opacity : 0.2
+		},
+		mark : {
+			backgroundColor : '#bfbfbf',
+			height          : 10,
+			width           : 3,
+			marginTop       : -3
+		},
+		markActive : {
+			opacity         : 1,
+			backgroundColor : 'currentColor'
+		}
+	})(Slider);
 
 const ListPeer = (props) =>
 {
@@ -252,6 +282,27 @@ const ListPeer = (props) =>
 						<Typography className={classes.moreActionsHeader}>
 							{peer.displayName}
 						</Typography>
+						<ListItem className={classes.nested}
+							disabled={!micConsumer || peer.stopPeerAudioInProgress}
+						>
+							<VolumeDownIcon />
+							<VolumeSlider className={classnames(classes.slider, classnames.setting)}
+								key={'audio-gain-slider'}
+								disabled={!micConsumer || peer.stopPeerAudioInProgress}
+								min={0}
+								max={2}
+								step={0.05}
+								value={micConsumer && micConsumer.audioGain !== undefined?
+									micConsumer.audioGain: 1}
+								valueLabelDisplay={'auto'}
+								onChange={
+									(event, value) =>
+									{
+										roomClient.setAudioGain(micConsumer, peer.id, value);
+									}}
+							/>
+							<VolumeUpIcon />
+						</ListItem>
 						<MenuItem
 							disabled={
 								peer.peerVideoInProgress ||

--- a/app/src/components/PeerAudio/AudioPeers.js
+++ b/app/src/components/PeerAudio/AudioPeers.js
@@ -21,6 +21,7 @@ const AudioPeers = (props) =>
 							key={micConsumer.id}
 							audioTrack={micConsumer.track}
 							audioOutputDevice={audioOutputDevice}
+							audioGain={micConsumer.audioGain}
 						/>
 					);
 				})

--- a/app/src/reducers/consumers.js
+++ b/app/src/reducers/consumers.js
@@ -97,6 +97,15 @@ const consumers = (state = initialState, action) =>
 			return { ...state, [consumerId]: newConsumer };
 		}
 
+		case 'SET_CONSUMER_AUDIO_GAIN':
+		{
+			const { consumerId, audioGain } = action.payload;
+			const consumer = state[consumerId];
+			const newConsumer = { ...consumer, audioGain };
+
+			return { ...state, [consumerId]: newConsumer };
+		}
+
 		case 'SET_CONSUMER_SCORE':
 		{
 			const { consumerId, score } = action.payload;


### PR DESCRIPTION
Addresses https://github.com/edumeet/edumeet/issues/505

The first working prototype of per-stream, client-side volume control.  Tested on FF86, Chromium 88.

Needs more testing, code-deduplication (some code lifted from `modifyPeerConsumer()`), possibly user-defined volume limit and steps and thorough review as I'm a web technologies beginner.
