### PR TITLE
Set expressSession proxy based on config.httpOnly

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -99,6 +99,7 @@ const session = expressSession({
 	resave            : true,
 	saveUninitialized : true,
 	store             : new RedisStore({ client: redisClient }),
+	proxy             : config.httpOnly === undefined? false: config.httpOnly,
 	cookie            : {
 		secure   : true,
 		httpOnly : true,


### PR DESCRIPTION
This change allows support for proxy communication with the Node server using plain HTTP and using "secure cookies" at the same time.

The [top voted answer here](https://stackoverflow.com/questions/30802322/node-js-express-session-what-does-the-proxy-option-do) has good explanation.
