### PR TITLE
Move the exit full-screen button to the left.

### DIFF
--- a/app/src/components/VideoContainers/FullScreenView.js
+++ b/app/src/components/VideoContainers/FullScreenView.js
@@ -33,7 +33,7 @@ const styles = (theme) =>
 		{
 			position       : 'absolute',
 			zIndex         : 1520,
-			right          : 0,
+			left           : 0,
 			top            : 0,
 			display        : 'flex',
 			flexDirection  : 'row',


### PR DESCRIPTION
Having the exit full-screen button in the top right corner is dangerous.
Given bad timing, when a presenter closes its screen-sharing session and
a viewer tries to minimize the presenter's shared screen, the viewer may
click the "leave" button instead and leave the conference.

By keeping the minimize button on the left in the same scenario the
viewer will open the chat instead which is still not ideal but more
acceptable.