### PR TITLE
Eslint no-shadow fix in _handleAudioLevelObservers() in room.js

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -560,6 +560,7 @@ class Room extends EventEmitter
 			{
 				const { producer, volume } = volumes[0];
 
+				// eslint-disable-next-line no-shadow
 				const audioLevelObject = this._audioLevelObservers.get(routerId);
 
 				audioLevelObject.peerId = producer.appData.peerId;
@@ -569,6 +570,7 @@ class Room extends EventEmitter
 
 			audioLevelObject.audioLevelObserver.on('silence', () =>
 			{
+				// eslint-disable-next-line no-shadow
 				const audioLevelObject = this._audioLevelObservers.get(routerId);
 
 				audioLevelObject.peerId = null;


### PR DESCRIPTION
If 'audioLevelObject' constant usage correct (shadowing), we need '// eslint-disable-next-line no-shadow' line.

If not, than 'const' keyword must be removed.

I wonder if I am wrong?