### PR TITLE
Keep avatar as a circle regardless of image aspect ratio

### DIFF
--- a/app/src/components/MeetingDrawer/Chat/Message.js
+++ b/app/src/components/MeetingDrawer/Chat/Message.js
@@ -50,6 +50,8 @@ const styles = (theme) =>
 		{
 			borderRadius : '50%',
 			height       : '2rem',
+			width        : '2rem',
+			objectFit    : 'cover',
 			alignSelf    : 'center'
 		}
 	});

--- a/app/src/components/MeetingDrawer/FileSharing/File.js
+++ b/app/src/components/MeetingDrawer/FileSharing/File.js
@@ -25,7 +25,9 @@ const styles = (theme) =>
 		avatar :
 		{
 			borderRadius : '50%',
-			height       : '2rem'
+			height       : '2rem',
+			width        : '2rem',
+			objectFit    : 'cover'
 		},
 		text :
 		{

--- a/app/src/components/MeetingDrawer/ParticipantList/ListMe.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListMe.js
@@ -24,6 +24,8 @@ const styles = (theme) =>
 		{
 			borderRadius : '50%',
 			height       : '2rem',
+			width        : '2rem',
+			objectFit    : 'cover',
 			marginTop    : theme.spacing(0.5)
 		},
 		peerInfo :

--- a/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
@@ -49,6 +49,8 @@ const styles = (theme) =>
 		{
 			borderRadius : '50%',
 			height       : '2rem',
+			width        : '2rem',
+			objectFit    : 'cover',
 			marginTop    : theme.spacing(0.5)
 		},
 		peerInfo :


### PR DESCRIPTION
Keep avatar as a circle regardless of image aspect ratio.
Otherwise horizontal or vertical images result in a ellipse as avatar.
And _objectFit_ that it doesn't get sqeezed or to center it kind of.  