### PR TITLE
Update service path to new dist/ folder and fixed access permissions for dist/server

### DIFF
--- a/edumeet.service
+++ b/edumeet.service
@@ -3,7 +3,7 @@ Description=edumeet is a audio / video meeting service running in the browser an
 After=network.target
 
 [Service]
-ExecStart=/usr/local/src/edumeet/server/server.js
+ExecStart=/usr/local/src/edumeet/server/dist/server.js
 Restart=always
 User=nobody
 Group=nogroup

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
 	"main": "lib/index.js",
 	"scripts": {
 		"start": "yarn build && node dist/server.js",
-		"build": "rm -rf dist && tsc && ln -s ../certs dist/certs && ln -s ../public dist/public",
+		"build": "rm -rf dist && tsc && ln -s ../certs dist/certs && ln -s ../public dist/public && chmod 755 dist/server.js",
 		"dev": "nodemon --exec ts-node --ignore dist/ -e js,ts server.js",
 		"connect": "ts-node connect.js",
 		"lint": "eslint -c .eslintrc.json --ext .js,.ts *.js *.ts lib/",


### PR DESCRIPTION
Updated service path to the new _dist/_ folder.
Left _WorkingDirectory_ the same because of the linked folders (but it seems to work also, if changed to the new one ... don't know if it should be updated too)

And fixed _dist/server.js_ access permissions (755), otherwise it throws error:
`edumeet.service: Failed at step EXEC spawning /usr/local/src/edumeet/server/dist/server.js: Permission denied`

In the source folder _connect.js_ got also 755 set, but i didn't add it, because it seems to work also without.