### PR TITLE
Rearange "build" folder to avoid mistakes with editing an auto generated content.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -78,7 +78,7 @@
 	"scripts": {
 		"analyze": "source-map-explorer build/static/js/*",
 		"start": "HTTPS=true PORT=4443 react-scripts start",
-		"build": "react-scripts build && mkdir -p ../server/public && rm -rf ../server/public/* && cp -r build/* ../server/public/",
+		"build": "react-scripts build && DEST='../server/dist/public' && mkdir -p $DEST && rm -rf $DEST/* && mv -T build/ $DEST",
 		"test": "react-scripts test",
 		"eject": "react-scripts eject",
 		"electron": "electron --no-sandbox .",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
 	"main": "lib/index.js",
 	"scripts": {
 		"start": "node dist/server.js",
-		"build": "rm -rf dist && tsc && ln -s ../certs dist/certs && ln -s ../public dist/public && chmod 755 dist/server.js",
+		"build": "mkdir -p dist && find dist/* -maxdepth 0 ! -name public -exec rm -rf {} \\; && tsc && ln -s ../certs dist/certs && chmod 755 dist/server.js",
 		"dev": "nodemon --exec ts-node --ignore dist/ -e js,ts server.js",
 		"connect": "ts-node connect.js",
 		"lint": "eslint -c .eslintrc.json --ext .js,.ts *.js *.ts lib/",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
 	"main": "lib/index.js",
 	"scripts": {
 		"start": "node dist/server.js",
-		"build": "mkdir -p dist && find dist/* -maxdepth 0 ! -name public -exec rm -rf {} \\; && tsc && ln -s ../certs dist/certs && chmod 755 dist/server.js",
+		"build": "mkdir -p dist && find dist/* -maxdepth 0 ! -name public -exec rm -rf {} \\; && tsc && ln -s ../certs dist/certs && chmod 755 dist/server.js && touch 'dist/ __AUTO_GENERATED_CONTENT_REFRESHED_AFTER_REBUILDING!__ '",
 		"dev": "nodemon --exec ts-node --ignore dist/ -e js,ts server.js",
 		"connect": "ts-node connect.js",
 		"lint": "eslint -c .eslintrc.json --ext .js,.ts *.js *.ts lib/",

--- a/server/server.js
+++ b/server/server.js
@@ -604,7 +604,7 @@ async function runHttpsServer()
 {
 	app.use(compression());
 
-	app.use('/.well-known/acme-challenge', express.static('public/.well-known/acme-challenge'));
+	app.use('/.well-known/acme-challenge', express.static('dist/public/.well-known/acme-challenge'));
 
 	app.all('*', async (req, res, next) =>
 	{
@@ -643,7 +643,7 @@ async function runHttpsServer()
 	});
 
 	// Serve all files in the public folder as static files.
-	app.use(express.static('public', {
+	app.use(express.static('dist/public', {
 		maxAge : config.staticFilesCachePeriod
 	}));
 


### PR DESCRIPTION
Related with #783

During building:
- [x] `mv -T` (prev : `cp`) `app/build` to `server/dist/public` path (prev: `server/public` with link `server/dist/public`). 

    Result:
     - `app/build/` doesn't exist anymore after [re]building in `app/`
     - `server/public/` doesn't exist anymore on the `server/` "level" (is hidden inside server/dist/
 
- [x] added a `server/dist/ __AUTO_GENERATED_CONTENT_REFRESHED_AFTER_REBUILDING!__` warning file
 
**What for**: 
Reducing the chance of accidentally editing auto-generated content (for example, configs) on the `server` and the `app` sides

`/server/dist` as the only place where the auto-generated data is stored (with special warning file inside it).