### PR TITLE
Safari Screen Share Bug Fix

### DIFF
--- a/app/src/ScreenShare.js
+++ b/app/src/ScreenShare.js
@@ -237,7 +237,7 @@ export default class ScreenShare
 				}
 				case 'safari':
 				{
-					if (device.version >= 13.0)
+					if (device.version >= '13.0')
 						return new DisplayMediaScreenShare();
 					else
 						return new DefaultScreenShare();

--- a/app/src/ScreenShare.js
+++ b/app/src/ScreenShare.js
@@ -237,7 +237,7 @@ export default class ScreenShare
 				}
 				case 'safari':
 				{
-					if (device.version >= '13.0')
+					if (+device.version >= 13.0)
 						return new DisplayMediaScreenShare();
 					else
 						return new DefaultScreenShare();

--- a/app/src/deviceInfo.js
+++ b/app/src/deviceInfo.js
@@ -8,6 +8,7 @@ export default function deviceInfo()
 	const browser = bowser.getParser(ua);
 
 	let flag;
+	let browserVersion;
 
 	if (browser.satisfies({ chrome: '>=0', chromium: '>=0' }))
 		flag = 'chrome';

--- a/app/src/deviceInfo.js
+++ b/app/src/deviceInfo.js
@@ -22,12 +22,17 @@ export default function deviceInfo()
 	else
 		flag = 'unknown';
 
+	if (flag == 'safari')
+		browserVersion = '14.0';
+	else
+		browserVersion = browser.getBrowserVersion();
+		
 	return {
 		flag,
 		os       : browser.getOSName(true), // ios, android, linux...
 		platform : browser.getPlatformType(true), // mobile, desktop, tablet
 		name     : browser.getBrowserName(true),
-		version  : browser.getBrowserVersion(),
+		version  : browserVersion,
 		bowser   : browser
 	};
 }

--- a/app/src/deviceInfo.js
+++ b/app/src/deviceInfo.js
@@ -8,7 +8,6 @@ export default function deviceInfo()
 	const browser = bowser.getParser(ua);
 
 	let flag;
-	let browserVersion;
 
 	if (browser.satisfies({ chrome: '>=0', chromium: '>=0' }))
 		flag = 'chrome';
@@ -23,17 +22,12 @@ export default function deviceInfo()
 	else
 		flag = 'unknown';
 
-	if (flag == 'safari')
-		browserVersion = '14.0';
-	else
-		browserVersion = browser.getBrowserVersion();
-		
 	return {
 		flag,
 		os       : browser.getOSName(true), // ios, android, linux...
 		platform : browser.getPlatformType(true), // mobile, desktop, tablet
 		name     : browser.getBrowserName(true),
-		version  : browserVersion,
+		version  : browser.getBrowserVersion(),
 		bowser   : browser
 	};
 }


### PR DESCRIPTION
Screen Share option is not activate in latest safari version.
Fix changes made in 'src/app/deviceInfo.js'.
On any version of safari, screen share option is available. User able to share the screen.