### PR TITLE
Fix - no token in session when reconnecting

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -673,6 +673,8 @@ class Room extends EventEmitter
 				const token = jwt.sign({ id: peer.id }, this._uuid, { noTimestamp: true });
 
 				peer.socket.handshake.session.token = token;
+				peer.socket.handshake.session.touch();
+				peer.socket.handshake.session.save();
 
 				let turnServers;
 


### PR DESCRIPTION
I have noticed, that sometimes when a peer gets disconnected from a call due to network problems, after automatically reconnecting he does not rejoin the room. What I have seen is again the problem of sync between the express session and the socket session, as we had with the logged in/out issue. I have added manual calls to touch and save the session, which made the token appear in the express session while reconnecting as it supposed to be. This has solved the issue for me. As this code has no influence on the processing, I will merge it.