### PR TITLE
Add automatic IP address detection

### DIFF
--- a/server/lib/config/config.ts
+++ b/server/lib/config/config.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import *  as path from 'path';
+import * as path from 'path';
 import convict from 'convict';
 import { ipaddress, url } from 'convict-format-with-validator';
 import json5 from 'json5';
@@ -32,7 +32,7 @@ import {
 const logger = new Logger('config');
 
 // add network interfaces list
-const ifaceWhiteListRegex = '^(eth.*)|(ens.*)|(br.*)'
+const ifaceWhiteListRegex = '^(eth.*)|(ens.*)|(br.*)|(wl.*)|(ww.*)';
 
 // add parsers
 convict.addParser([
@@ -48,18 +48,25 @@ function assert(assertion: Boolean, msg: string)
 	if (!assertion)
 		throw new Error(msg);
 }
+
 // add automatic IP detection
-function getListenIps() {
-	let listenIP = [];
+function getListenIps()
+{
+	const listenIP = [];
 	const ifaces = networkInterfaces();
-	Object.keys(ifaces).forEach(function (ifname) {
-		if (ifname.match(ifaceWhiteListRegex)) {
-			ifaces[ifname].forEach(function (iface) {
+
+	Object.keys(ifaces).forEach(function(ifname)
+	{
+		if (ifname.match(ifaceWhiteListRegex))
+		{
+			ifaces[ifname].forEach(function(iface)
+			{
 				if (
-					(iface.family !== "IPv4" &&
-						(iface.family !== "IPv6" || iface.scopeid !== 0)) ||
+					(iface.family !== 'IPv4' &&
+						(iface.family !== 'IPv6' || iface.scopeid !== 0)) ||
 					iface.internal !== false
-				) {
+				)
+				{
 					// skip over internal (i.e. 127.0.0.1) and non-ipv4 or ipv6 non global addresses
 					return;
 				}
@@ -67,7 +74,14 @@ function getListenIps() {
 			});
 		}
 	});
+
+	if (listenIP.length === 0)
+	{
+		listenIP.push({ ip: '0.0.0.0', announcedIp: null });
+	}
+
 	logger.info('discovered IP adresses:', JSON.stringify(listenIP, null, 4));
+
 	return listenIP;
 }
 
@@ -545,6 +559,7 @@ catch (error: any)
 
 // load additional config module (no validation is performed)
 const configModuleFilepath = path.normalize(`${__dirname}/../../config/config.js`);
+
 if (fs.existsSync(configModuleFilepath))
 {
 	try


### PR DESCRIPTION
Based on edumeet-docker configuration option (@misi)

This function discovers available IPv4 & IPv6  addresses and populate  _**"listenIps"**_ variable needed by mediasoup WebRtcTransport settings (https://mediasoup.org/documentation/v3/mediasoup/api/#TransportListenIp)

User can override this by setting _**"listenIps"**_ in custom _config.yaml_ file (example)
```
mediasoup:
  webRtcTransport:
    listenIps:
    - ip: "1.2.3.4"
      announcedIp: ""
```