### PR TITLE
Fix session overwrites

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -301,6 +301,8 @@ class Room extends EventEmitter
 		this._handleLobby();
 
 		this._handleAudioLevelObservers();
+
+		this._tokens = new Map();
 	}
 
 	isLocked()
@@ -356,8 +358,15 @@ class Room extends EventEmitter
 
 		this._mediasoupRouters.clear();
 
+		this._tokens.clear();
+
 		// Emit 'close' event.
 		this.emit('close');
+	}
+
+	getToken(peerId)
+	{
+		return this._tokens.get(peerId);
 	}
 
 	verifyPeer({ id, token })
@@ -672,9 +681,7 @@ class Room extends EventEmitter
 			{
 				const token = jwt.sign({ id: peer.id }, this._uuid, { noTimestamp: true });
 
-				peer.socket.handshake.session.token = token;
-				peer.socket.handshake.session.touch();
-				peer.socket.handshake.session.save();
+				this._tokens.set(peer.id, token);
 
 				let turnServers;
 

--- a/server/server.js
+++ b/server/server.js
@@ -733,7 +733,11 @@ async function runWebSocketServer()
 		{
 			const room = await getOrCreateRoom({ roomId });
 
-			const token = room.getToken(peerId);
+			let token = null;
+			if (socket.handshake.session.peerId === peerId)
+			{
+				token = room.getToken(peerId);
+			}
 
 			let peer = peers.get(peerId);
 			let returning = false;
@@ -790,6 +794,7 @@ async function runWebSocketServer()
 
 			room.handlePeer({ peer, returning });
 
+			socket.handshake.session.peerId = peer.id;
 			socket.handshake.session.touch();
 			socket.handshake.session.save();
 

--- a/server/server.js
+++ b/server/server.js
@@ -731,9 +731,9 @@ async function runWebSocketServer()
 
 		queue.push(async () =>
 		{
-			const { token } = socket.handshake.session;
-
 			const room = await getOrCreateRoom({ roomId });
+
+			const token = room.getToken(peerId);
 
 			let peer = peers.get(peerId);
 			let returning = false;


### PR DESCRIPTION
A long fight with the shared session between express and SocketIO. 
Recently I have fixed the bug that the peer returning mechanism did not work, as the token set in session was not saved for the retry connection. I forced to save session and it started to work again. But now I have noticed, that this manual saving caused the old bug to reappear, the one that if you log in from lobby and press F5 you are not logged in. This is because the passport things are not in the session. So the solution is, we must only write to express session and can then read from both express and SocketIO. I have now changed the token mechanism, so the tokens are saved in the room object and not in the session. This is I think a better approach, as the tokens are only valid with the current instance of the room. No need to have them in the session.