### PR TITLE
Fix not closing extra video producers od disconnect

### DIFF
--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -2704,6 +2704,15 @@ export default class RoomClient
 				this._webcamProducer = null;
 			}
 
+			for (const producer of this._extraVideoProducers.values())
+			{
+				producer.close();
+
+				store.dispatch(
+					producerActions.removeProducer(producer.id));
+			}
+			this._extraVideoProducers.clear();
+
 			if (this._micProducer)
 			{
 				this._micProducer.close();


### PR DESCRIPTION
We did not close extra videos on disconnect. This was causing, that if a reconnect succeeded, we were left with a black window.