### PR TITLE
add imprint and privacy notice configuration to run-first.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ docker-compose up -d
 This will start all the services. And you are done. You can now access the service at the main domain you provided.
 
 ### Configuration
-The configuration for the client is in the `client` folder. You may change it as needed, but no changes are necessary for the service to work. The configuration for the room-server is in the `room-server` folder. You may change it as needed, but no changes are necessary for the service to work.
+The configuration for the client is in the `client` folder. You may change it as needed, but no changes are necessary for the service to work.
+An example for this configuration file can be found in the [edumeet-client](https://github.com/edumeet/edumeet-client?tab=readme-ov-file#configuration-properties) repository. The configuration for the room-server is in the `room-server` folder. You may change it as needed, but no changes are necessary for the service to work.
+An example for this configuration file can be found in the [edumeet-room-server](https://github.com/edumeet/edumeet-room-server?tab=readme-ov-file#configuration-properties) repository.
 
 ## Community-driven support
 | Type                |                                                |

--- a/run-first.sh
+++ b/run-first.sh
@@ -35,6 +35,40 @@ EXTERNAL_IP=$EXTERNAL_IP
 MEDIA_SECRET=$MEDIA_SECRET
 EOF
 
+# Configure edumeet-client
+if [[ "$(cat client/config.js)" == "var config = {};" ]]; then
+    while true; do
+        read -p "Do you want to configure edumeet-client now? You can do it later in client/config.js (y/n): " do_client_config
+        case "$do_client_config" in
+            [yY])
+                [ -z "$TITLE" ] && read -p "Enter name of your edumeet: " TITLE
+                echo "If you don't want to show links to your imprint or privacy notes, please skip the following questions."
+                [ -z "$IMPRINT_URL" ] && read -p "Enter URL of your imprint: " IMPRINT_URL
+                [ -z "$PRIVACY_URL" ] && read -p "Enter URL of your privacy notes " PRIVACY_URL
+
+                cat <<EOF > client/config.js
+var config = {
+        title: "$TITLE",
+        imprintUrl: "$IMPRINT_URL",
+        privacyUrl: "$PRIVACY_URL",
+};
+EOF
+
+                break
+                ;;
+            [nN])
+                echo "Skipping configuration of edumeet-client."
+                break
+                ;;
+            *)
+                echo "Invalid input. Please type 'y' or 'n'."
+                ;;
+        esac
+    done
+else
+    echo "Found existing configuration for edumeet-client. Skipping its config."
+fi
+
 # Define other variables
 domains=($MAIN_DOMAIN $MEDIA_DOMAIN)
 rsa_key_size=4096


### PR DESCRIPTION
In accordance to https://github.com/edumeet/edumeet-client/pull/199 we improved the `run-first.sh` to ask the user for some basic configuration of the edumeet-client configuration file.

For now this includes the title of the instance as well as the (optional) links to an imprint and privacy notices.

To make the setup easier for newcomers we referenced the documentation of the edumeet-client and edumeet-room-server config file options in the README.