### PR TITLE
In run-first.sh tells the user to not set 0.0.0.0 as LISTEN_IP

### DIFF
--- a/run-first.sh
+++ b/run-first.sh
@@ -20,8 +20,9 @@ fi
 [ -z "$MAIN_DOMAIN" ] && read -p "Enter Main FQDN: " MAIN_DOMAIN
 [ -z "$MEDIA_DOMAIN" ] && read -p "Enter Media FQDN (MUST be different from Main Domain): " MEDIA_DOMAIN
 [ -z "$EMAIL" ] && read -p "Enter Email: " EMAIL
-[ -z "$LISTEN_IP" ] && read -p "Enter Listen IP: " LISTEN_IP
 [ -z "$EXTERNAL_IP" ] && read -p "Enter Public IP: " EXTERNAL_IP
+[ -z "$LISTEN_IP" ] && read -p "Enter Listen IP (MUST NOT be 0.0.0.0 or MEDIA won't work. Defaults to $EXTERNAL_IP): " LISTEN_IP
+[ -z "$LISTEN_IP" ] && LISTEN_IP=$EXTERNAL_IP
 # Always generate a new Media Secret
 MEDIA_SECRET=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 20)
 


### PR DESCRIPTION
Hello,
I have experimented weird behaviour with my brand new setup of edumeet.
This was due to set LISTEN_IP to 0.0.0.0 that cannot be used.

So i adapted run-first.sh script to avoid setting that value. I did not check for errors if user still insert it, but I see that there are not too many checks on value inserted. I add the plus that if the LISTEN_IP is not specified, it will be equal to EXTERNAL_IP

I hope it could be useful for others.
Thanks for your work that after 5 years is flying high!